### PR TITLE
should fix disappearing category issue

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -1,5 +1,5 @@
 {
-    "name": "kiwiphoenix364/pxt-mini-tilemaps",
+    "name": "pxt-mini-tilemaps",
     "version": "2.0.3",
     "description": "",
     "dependencies": {


### PR DESCRIPTION
Should fix the category disappearing when you refresh; after we compile a version of an extension for the first time we cache the results, and having a slash here appears to be interpreted as a part of the path / break the caching. My version with this fixed appears to work fine: https://github.com/jwunderl/pxt-mini-tilemaps